### PR TITLE
fix: support prototools ^0.42.0

### DIFF
--- a/plugins/gh.toml
+++ b/plugins/gh.toml
@@ -6,16 +6,19 @@ type = "cli"
 
 [platform.linux]
 bin-path = "bin/gh"
+exe-path = "bin/gh"
 archive-prefix = "gh_{version}_linux_{arch}"
 download-file = "gh_{version}_linux_{arch}.tar.gz"
 
 [platform.macos]
 bin-path = "bin/gh"
+exe-path = "bin/gh"
 archive-prefix = "gh_{version}_macOS_{arch}"
 download-file = "gh_{version}_macOS_{arch}.zip"
 
 [platform.windows]
 bin-path = "bin/gh.exe"
+exe-path = "bin/gh.exe"
 archive-prefix = "gh_{version}_windows_{arch}"
 download-file = "gh_{version}_windows_{arch}.zip"
 


### PR DESCRIPTION
### Without the fix:

```shell
proto --version
proto 0.41.7

monorepo on  fou-1901-make-monorepo-compatible-with-prototools-0420 [$!⇕] via  v20.16.0 
❯ proto install  
   yarn ━━━━━━━━━━━━━━━━━━━━ | yarn 1.18.0 already installed!
doppler ━━━━━━━━━━━━━━━━━━━━ | doppler 3.68.0 already installed!
   node ━━━━━━━━━━━━━━━━━━━━ | Node.js 20.16.0 already installed!
     gh ━━━━━━━━━━━━━━━━━━━━ | gh 2.42.0 already installed!
kubectl ━━━━━━━━━━━━━━━━━━━━ | kubectl 1.29.0 already installed!
  doctl ━━━━━━━━━━━━━━━━━━━━ | doctl 1.106.0 already installed!
   helm ━━━━━━━━━━━━━━━━━━━━ | helm 3.13.3 already installed!       
```

```
❯ proto --version
proto 0.42.0

monorepo on fou-1901-make-monorepo-compatible-with-prototools-0420 [$!⇕] via  v20.8.1 
❯ proto install  
     gh ━━━━━━━━━━━━━━━━━━━━ | Installing gh 2.42.0
  doctl ━━━━━━━━━━━━━━━━━━━━ | Installing doctl 1.106.0
   helm ━━━━━━━━━━━━━━━━━━━━ | Installing helm 3.13.3
   yarn ━━━━━━━━━━━━━━━━━━━━ | yarn 1.18.0 already installed!
   node ━━━━━━━━━━━━━━━━━━━━ | Node.js 20.16.0 already installed!
kubectl ━━━━━━━━━━━━━━━━━━━━ | Installing kubectl 1.29.0
doppler ━━━━━━━━━━━━━━━━━━━━ | Installing doppler 3.68.0                                                                                       
  doctl ━━━━━━━━━━━━━━━━━━━━ | doctl 1.106.0 already installed!
   helm ━━━━━━━━━━━━━━━━━━━━ | helm 3.13.3 already installed!
   yarn ━━━━━━━━━━━━━━━━━━━━ | yarn 1.18.0 already installed!
   node ━━━━━━━━━━━━━━━━━━━━ | Node.js 20.16.0 already installed!
kubectl ━━━━━━━━━━━━━━━━━━━━ | kubectl 1.29.0 already installed!
doppler ━━━━━━━━━━━━━━━━━━━━ | doppler 3.68.0 already installed!                                                                               Error: proto::execute::missing_file

  × Unable to find an executable for gh, expected file ~/.proto/tools/gh/2.42.0/gh does not exist.
```

### With the Fix

```shell
❯ proto --version
proto 0.41.7

monorepo on  fou-1901-make-monorepo-compatible-with-prototools-0420 [$!] via  v20.16.0 
❯ proto install  
kubectl ━━━━━━━━━━━━━━━━━━━━ | kubectl 1.29.0 already installed!
     gh ━━━━━━━━━━━━━━━━━━━━ | gh 2.42.0 already installed!
   helm ━━━━━━━━━━━━━━━━━━━━ | helm 3.13.3 already installed!
   node ━━━━━━━━━━━━━━━━━━━━ | Node.js 20.16.0 already installed!
doppler ━━━━━━━━━━━━━━━━━━━━ | doppler 3.68.0 already installed!
  doctl ━━━━━━━━━━━━━━━━━━━━ | doctl 1.106.0 already installed!
   yarn ━━━━━━━━━━━━━━━━━━━━ | yarn 1.18.0 already installed!    
```

```shell
❯ proto --version
proto 0.42.0

monorepo on  fou-1901-make-monorepo-compatible-with-prototools-0420 [$!] via  v20.16.0 
❯ proto install  
     gh ━━━━━━━━━━━━━━━━━━━━ | gh 2.42.0 already installed!
   node ━━━━━━━━━━━━━━━━━━━━ | Node.js 20.16.0 already installed!
  doctl ━━━━━━━━━━━━━━━━━━━━ | doctl 1.106.0 already installed!
   helm ━━━━━━━━━━━━━━━━━━━━ | helm 3.13.3 already installed!
kubectl ━━━━━━━━━━━━━━━━━━━━ | kubectl 1.29.0 already installed!
doppler ━━━━━━━━━━━━━━━━━━━━ | doppler 3.68.0 already installed!
   yarn ━━━━━━━━━━━━━━━━━━━━ | yarn 1.18.0 already installed!       
```